### PR TITLE
Konsumer Arena AAP-vedtak og publiser til api-intern-hendelse-v1

### DIFF
--- a/.nais/application-dev.yml
+++ b/.nais/application-dev.yml
@@ -50,3 +50,7 @@ spec:
   env:
     - name: HENDELSE_TOPIC
       value: pensjonsamhandling.sam-vedtak-hendelser-q2
+    - name: ARENA_VEDTAK_TOPIC
+      value: teamarenanais.aapen-arena-aapvedtakendret-v1-q2
+    - name: INTERN_HENDELSE_TOPIC
+      value: aap.api-intern-hendelse-v1

--- a/.nais/application-prod.yml
+++ b/.nais/application-prod.yml
@@ -50,3 +50,7 @@ spec:
   env:
     - name: HENDELSE_TOPIC
       value: pensjonsamhandling.sam-vedtak-hendelser-p
+    - name: ARENA_VEDTAK_TOPIC
+      value: teamarenanais.aapen-arena-aapvedtakendret-v1-prod
+    - name: INTERN_HENDELSE_TOPIC
+      value: aap.api-intern-hendelse-v1

--- a/app/src/main/kotlin/no/nav/aap/proxy/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/proxy/App.kt
@@ -10,11 +10,15 @@ import io.ktor.server.netty.*
 import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import no.nav.aap.komponenter.server.AZURE
 import no.nav.aap.komponenter.server.commonKtorModule
 import no.nav.aap.proxy.hendelse.hendelse
+import no.nav.aap.proxy.kafka.AapInternHendelseProducer
+import no.nav.aap.proxy.kafka.ArenaKafkaConsumer
 import no.nav.aap.proxy.kafka.HendelseApiKafkaProducer
 import no.nav.aap.proxy.kafka.HendelseProducer
 import org.slf4j.Logger
@@ -30,17 +34,23 @@ fun main() {
         )
     }
     val config = Config()
+    val internHendelseProducer = AapInternHendelseProducer(config.kafka, config.internHendelseTopic)
+    val arenaKafkaConsumer = ArenaKafkaConsumer(config.kafka, config.arenaVedtakTopic, internHendelseProducer)
     embeddedServer(Netty, port = 8080) {
         server(
             config,
             HendelseApiKafkaProducer(config.kafka, config.topicConfig),
+            arenaKafkaConsumer,
+            internHendelseProducer,
         )
     }.start(wait = true)
 }
 
 fun Application.server(
     config: Config,
-    hendelseProducer: HendelseProducer
+    hendelseProducer: HendelseProducer,
+    arenaKafkaConsumer: ArenaKafkaConsumer? = null,
+    internHendelseProducer: AapInternHendelseProducer? = null,
 ) {
     commonKtorModule(
         prometheus = prometheus,
@@ -62,10 +72,20 @@ fun Application.server(
         }
     }
 
+    monitor.subscribe(ApplicationStarted) {
+        arenaKafkaConsumer?.let { consumer ->
+            launch(Dispatchers.IO) {
+                consumer.start()
+            }
+        }
+    }
+
     monitor.subscribe(ApplicationStopping) {
         runBlocking {
             delay(50)
         }
+        arenaKafkaConsumer?.close()
+        internHendelseProducer?.close()
         hendelseProducer.close()
     }
 

--- a/app/src/main/kotlin/no/nav/aap/proxy/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/proxy/App.kt
@@ -21,6 +21,7 @@ import no.nav.aap.proxy.kafka.AapInternHendelseProducer
 import no.nav.aap.proxy.kafka.ArenaKafkaConsumer
 import no.nav.aap.proxy.kafka.HendelseApiKafkaProducer
 import no.nav.aap.proxy.kafka.HendelseProducer
+import no.nav.aap.proxy.kafka.InternHendelseProducer
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -50,7 +51,7 @@ fun Application.server(
     config: Config,
     hendelseProducer: HendelseProducer,
     arenaKafkaConsumer: ArenaKafkaConsumer? = null,
-    internHendelseProducer: AapInternHendelseProducer? = null,
+    internHendelseProducer: InternHendelseProducer? = null,
 ) {
     commonKtorModule(
         prometheus = prometheus,

--- a/app/src/main/kotlin/no/nav/aap/proxy/Config.kt
+++ b/app/src/main/kotlin/no/nav/aap/proxy/Config.kt
@@ -13,4 +13,6 @@ data class Config(
         credstorePsw = requiredConfigForKey("kafka.credstore.password"),
     ),
     val topicConfig: String = requiredConfigForKey("hendelse.topic"),
+    val arenaVedtakTopic: String = requiredConfigForKey("arena.vedtak.topic"),
+    val internHendelseTopic: String = requiredConfigForKey("intern.hendelse.topic"),
 )

--- a/app/src/main/kotlin/no/nav/aap/proxy/kafka/AapHendelseRecord.kt
+++ b/app/src/main/kotlin/no/nav/aap/proxy/kafka/AapHendelseRecord.kt
@@ -1,0 +1,11 @@
+package no.nav.aap.proxy.kafka
+
+data class AapHendelseRecord(
+    val ident: String,
+    val hendelse: Hendelse,
+)
+
+enum class Hendelse {
+    VEDTAK,
+    SOKNAD,
+}

--- a/app/src/main/kotlin/no/nav/aap/proxy/kafka/AapInternHendelseProducer.kt
+++ b/app/src/main/kotlin/no/nav/aap/proxy/kafka/AapInternHendelseProducer.kt
@@ -6,10 +6,14 @@ import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger(AapInternHendelseProducer::class.java)
 
-class AapInternHendelseProducer(config: KafkaConfig, private val topic: String) : AutoCloseable {
+interface InternHendelseProducer : AutoCloseable {
+    fun produce(record: AapHendelseRecord)
+}
+
+class AapInternHendelseProducer(config: KafkaConfig, private val topic: String) : InternHendelseProducer {
     private val producer = KafkaFactory.createProducer("aap-intern-hendelse-producer", config)
 
-    fun produce(record: AapHendelseRecord) {
+    override fun produce(record: AapHendelseRecord) {
         val json = DefaultJsonMapper.toJson(record)
         producer.send(ProducerRecord(topic, record.ident, json)) { metadata, err ->
             if (err != null) {

--- a/app/src/main/kotlin/no/nav/aap/proxy/kafka/AapInternHendelseProducer.kt
+++ b/app/src/main/kotlin/no/nav/aap/proxy/kafka/AapInternHendelseProducer.kt
@@ -17,10 +17,10 @@ class AapInternHendelseProducer(config: KafkaConfig, private val topic: String) 
         val json = DefaultJsonMapper.toJson(record)
         producer.send(ProducerRecord(topic, record.ident, json)) { metadata, err ->
             if (err != null) {
-                logger.error("Feil ved publisering av intern hendelse for ${record.ident}", err)
-                throw KafkaProducerException("Feil ved publisering av intern hendelse for ${record.ident}")
+                logger.error("Feil ved publisering av intern hendelse", err)
+                throw KafkaProducerException("Feil ved publisering av intern hendelse")
             } else {
-                logger.debug("Publiserte intern hendelse for {}: {}", record.ident, metadata)
+                logger.debug("Publiserte intern hendelse: {}", metadata)
             }
         }.get()
     }

--- a/app/src/main/kotlin/no/nav/aap/proxy/kafka/AapInternHendelseProducer.kt
+++ b/app/src/main/kotlin/no/nav/aap/proxy/kafka/AapInternHendelseProducer.kt
@@ -1,0 +1,25 @@
+package no.nav.aap.proxy.kafka
+
+import no.nav.aap.komponenter.json.DefaultJsonMapper
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger(AapInternHendelseProducer::class.java)
+
+class AapInternHendelseProducer(config: KafkaConfig, private val topic: String) : AutoCloseable {
+    private val producer = KafkaFactory.createProducer("aap-intern-hendelse-producer", config)
+
+    fun produce(record: AapHendelseRecord) {
+        val json = DefaultJsonMapper.toJson(record)
+        producer.send(ProducerRecord(topic, record.ident, json)) { metadata, err ->
+            if (err != null) {
+                logger.error("Feil ved publisering av intern hendelse for ${record.ident}", err)
+                throw KafkaProducerException("Feil ved publisering av intern hendelse for ${record.ident}")
+            } else {
+                logger.debug("Publiserte intern hendelse for {}: {}", record.ident, metadata)
+            }
+        }.get()
+    }
+
+    override fun close() = producer.close()
+}

--- a/app/src/main/kotlin/no/nav/aap/proxy/kafka/ArenaKafkaConsumer.kt
+++ b/app/src/main/kotlin/no/nav/aap/proxy/kafka/ArenaKafkaConsumer.kt
@@ -8,12 +8,19 @@ import java.time.Duration
 private val logger = LoggerFactory.getLogger(ArenaKafkaConsumer::class.java)
 
 class ArenaKafkaConsumer(
-    config: KafkaConfig,
     private val arenaVedtakTopic: String,
-    private val internHendelseProducer: AapInternHendelseProducer,
+    private val internHendelseProducer: InternHendelseProducer,
+    private val consumer: Consumer<String, String>,
 ) : AutoCloseable {
-    private val consumer: Consumer<String, String> =
-        KafkaFactory.createConsumer("aap-arena-vedtak-consumer", config)
+    constructor(
+        config: KafkaConfig,
+        arenaVedtakTopic: String,
+        internHendelseProducer: InternHendelseProducer,
+    ) : this(
+        arenaVedtakTopic,
+        internHendelseProducer,
+        KafkaFactory.createConsumer("aap-arena-vedtak-consumer", config),
+    )
 
     @Volatile
     private var running = true
@@ -26,13 +33,7 @@ class ArenaKafkaConsumer(
             for (record in records) {
                 try {
                     val arenaRecord = DefaultJsonMapper.fromJson<ArenaVedtakRecord>(record.value())
-                    if (arenaRecord.opType == "D") continue
-                    val vedtakData = arenaRecord.after ?: continue
-                    val hendelseRecord = AapHendelseRecord(
-                        ident = vedtakData.personident,
-                        hendelse = Hendelse.VEDTAK,
-                    )
-                    internHendelseProducer.produce(hendelseRecord)
+                    mapToHendelse(arenaRecord)?.let { internHendelseProducer.produce(it) }
                 } catch (e: Exception) {
                     logger.error("Feil ved prosessering av arena-vedtak-record offset={}", record.offset(), e)
                 }
@@ -41,6 +42,15 @@ class ArenaKafkaConsumer(
                 consumer.commitSync()
             }
         }
+    }
+
+    internal fun mapToHendelse(record: ArenaVedtakRecord): AapHendelseRecord? {
+        if (record.opType == "D") return null
+        val vedtakData = record.after ?: return null
+        return AapHendelseRecord(
+            ident = vedtakData.personident,
+            hendelse = Hendelse.VEDTAK,
+        )
     }
 
     override fun close() {

--- a/app/src/main/kotlin/no/nav/aap/proxy/kafka/ArenaKafkaConsumer.kt
+++ b/app/src/main/kotlin/no/nav/aap/proxy/kafka/ArenaKafkaConsumer.kt
@@ -1,0 +1,50 @@
+package no.nav.aap.proxy.kafka
+
+import no.nav.aap.komponenter.json.DefaultJsonMapper
+import org.apache.kafka.clients.consumer.Consumer
+import org.slf4j.LoggerFactory
+import java.time.Duration
+
+private val logger = LoggerFactory.getLogger(ArenaKafkaConsumer::class.java)
+
+class ArenaKafkaConsumer(
+    config: KafkaConfig,
+    private val arenaVedtakTopic: String,
+    private val internHendelseProducer: AapInternHendelseProducer,
+) : AutoCloseable {
+    private val consumer: Consumer<String, String> =
+        KafkaFactory.createConsumer("aap-arena-vedtak-consumer", config)
+
+    @Volatile
+    private var running = true
+
+    fun start() {
+        consumer.subscribe(listOf(arenaVedtakTopic))
+        logger.info("Starter konsumering fra {}", arenaVedtakTopic)
+        while (running) {
+            val records = consumer.poll(Duration.ofSeconds(5))
+            for (record in records) {
+                try {
+                    val arenaRecord = DefaultJsonMapper.fromJson<ArenaVedtakRecord>(record.value())
+                    if (arenaRecord.opType == "D") continue
+                    val vedtakData = arenaRecord.after ?: continue
+                    val hendelseRecord = AapHendelseRecord(
+                        ident = vedtakData.personident,
+                        hendelse = Hendelse.VEDTAK,
+                    )
+                    internHendelseProducer.produce(hendelseRecord)
+                } catch (e: Exception) {
+                    logger.error("Feil ved prosessering av arena-vedtak-record offset={}", record.offset(), e)
+                }
+            }
+            if (!records.isEmpty) {
+                consumer.commitSync()
+            }
+        }
+    }
+
+    override fun close() {
+        running = false
+        consumer.wakeup()
+    }
+}

--- a/app/src/main/kotlin/no/nav/aap/proxy/kafka/ArenaVedtakRecord.kt
+++ b/app/src/main/kotlin/no/nav/aap/proxy/kafka/ArenaVedtakRecord.kt
@@ -1,0 +1,17 @@
+package no.nav.aap.proxy.kafka
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ArenaVedtakRecord(
+    @JsonProperty("op_type") val opType: String,
+    val before: AapVedtakData?,
+    val after: AapVedtakData?,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AapVedtakData(
+    @JsonProperty("PERSONIDENT") val personident: String,
+    @JsonProperty("VEDTAK_ID") val vedtakId: Long,
+)

--- a/app/src/main/kotlin/no/nav/aap/proxy/kafka/KafkaFactory.kt
+++ b/app/src/main/kotlin/no/nav/aap/proxy/kafka/KafkaFactory.kt
@@ -1,6 +1,9 @@
 package no.nav.aap.proxy.kafka
 
 import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.Producer
 import org.apache.kafka.clients.producer.ProducerConfig
@@ -51,5 +54,25 @@ class KafkaFactory private constructor() {
 
         fun createProducer(clientId: String, config: KafkaConfig): Producer<String, String> =
             createProducer(clientId, config, StringSerde().serializer())
+
+        fun createConsumer(groupId: String, config: KafkaConfig): Consumer<String, String> {
+            fun properties(): Properties = Properties().apply {
+                this[CommonClientConfigs.CLIENT_ID_CONFIG] = groupId
+                this[ConsumerConfig.GROUP_ID_CONFIG] = groupId
+                this[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = config.brokers
+                this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
+                this[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = "false"
+                this[CommonClientConfigs.SECURITY_PROTOCOL_CONFIG] = "SSL"
+                this[SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG] = "JKS"
+                this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = config.truststorePath
+                this[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = config.credstorePsw
+                this[SslConfigs.SSL_KEYSTORE_TYPE_CONFIG] = "PKCS12"
+                this[SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG] = config.keystorePath
+                this[SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG] = config.credstorePsw
+                this[SslConfigs.SSL_KEY_PASSWORD_CONFIG] = config.credstorePsw
+                this[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] = ""
+            }
+            return KafkaConsumer(properties(), StringSerde().deserializer(), StringSerde().deserializer())
+        }
     }
 }

--- a/app/src/test/kotlin/no/nav/aap/proxy/AppTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/proxy/AppTest.kt
@@ -32,6 +32,8 @@ class AppTest {
             System.setProperty("kafka.keystore.path", "...")
             System.setProperty("kafka.credstore.password", "...")
             System.setProperty("hendelse.topic", "...")
+            System.setProperty("arena.vedtak.topic", "...")
+            System.setProperty("intern.hendelse.topic", "...")
         }
 
         @BeforeAll

--- a/app/src/test/kotlin/no/nav/aap/proxy/ArenaKafkaConsumerTest.kt
+++ b/app/src/test/kotlin/no/nav/aap/proxy/ArenaKafkaConsumerTest.kt
@@ -1,0 +1,62 @@
+package no.nav.aap.proxy.kafka
+
+import org.apache.kafka.clients.consumer.MockConsumer
+import org.apache.kafka.clients.consumer.OffsetResetStrategy
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ArenaKafkaConsumerTest {
+
+    private val published = mutableListOf<AapHendelseRecord>()
+    private val mockProducer = object : InternHendelseProducer {
+        override fun produce(record: AapHendelseRecord) { published.add(record) }
+        override fun close() {}
+    }
+    private val consumer = ArenaKafkaConsumer(
+        arenaVedtakTopic = "test-topic",
+        internHendelseProducer = mockProducer,
+        consumer = MockConsumer(OffsetResetStrategy.EARLIEST),
+    )
+
+    @Test
+    fun `INSERT produserer hendelse med riktig ident`() {
+        val record = ArenaVedtakRecord(
+            opType = "I",
+            before = null,
+            after = AapVedtakData(personident = "12345678901", vedtakId = 42),
+        )
+        val result = consumer.mapToHendelse(record)
+        assertThat(result).isEqualTo(AapHendelseRecord(ident = "12345678901", hendelse = Hendelse.VEDTAK))
+    }
+
+    @Test
+    fun `UPDATE bruker after-feltet for ident`() {
+        val record = ArenaVedtakRecord(
+            opType = "U",
+            before = AapVedtakData(personident = "00000000000", vedtakId = 1),
+            after = AapVedtakData(personident = "12345678901", vedtakId = 42),
+        )
+        val result = consumer.mapToHendelse(record)
+        assertThat(result).isEqualTo(AapHendelseRecord(ident = "12345678901", hendelse = Hendelse.VEDTAK))
+    }
+
+    @Test
+    fun `DELETE hoppes over`() {
+        val record = ArenaVedtakRecord(
+            opType = "D",
+            before = AapVedtakData(personident = "12345678901", vedtakId = 42),
+            after = null,
+        )
+        assertThat(consumer.mapToHendelse(record)).isNull()
+    }
+
+    @Test
+    fun `manglende after hoppes over`() {
+        val record = ArenaVedtakRecord(
+            opType = "U",
+            before = AapVedtakData(personident = "12345678901", vedtakId = 42),
+            after = null,
+        )
+        assertThat(consumer.mapToHendelse(record)).isNull()
+    }
+}


### PR DESCRIPTION
Arena fases ut, og konsumenter skal slippe å håndtere Arenas komplekse CDC-format selv. Denne proxyen lytter på aapen-arena-aapvedtakendret-v1 og republiserer hendelsene i et enklere format til api-intern-hendelse-v1, slik at konsumenter kun trenger å lytte på ett topic.