### PR TITLE
Stopp lesing fra arena-vedtak-topic i dev

### DIFF
--- a/.nais/application-dev.yml
+++ b/.nais/application-dev.yml
@@ -50,7 +50,5 @@ spec:
   env:
     - name: HENDELSE_TOPIC
       value: pensjonsamhandling.sam-vedtak-hendelser-q2
-    - name: ARENA_VEDTAK_TOPIC
-      value: teamarenanais.aapen-arena-aapvedtakendret-v1-q2
     - name: INTERN_HENDELSE_TOPIC
       value: aap.api-intern-hendelse-v1

--- a/app/src/main/kotlin/no/nav/aap/proxy/App.kt
+++ b/app/src/main/kotlin/no/nav/aap/proxy/App.kt
@@ -36,7 +36,9 @@ fun main() {
     }
     val config = Config()
     val internHendelseProducer = AapInternHendelseProducer(config.kafka, config.internHendelseTopic)
-    val arenaKafkaConsumer = ArenaKafkaConsumer(config.kafka, config.arenaVedtakTopic, internHendelseProducer)
+    val arenaKafkaConsumer = config.arenaVedtakTopic?.let {
+        ArenaKafkaConsumer(config.kafka, it, internHendelseProducer)
+    }
     embeddedServer(Netty, port = 8080) {
         server(
             config,

--- a/app/src/main/kotlin/no/nav/aap/proxy/Config.kt
+++ b/app/src/main/kotlin/no/nav/aap/proxy/Config.kt
@@ -13,6 +13,6 @@ data class Config(
         credstorePsw = requiredConfigForKey("kafka.credstore.password"),
     ),
     val topicConfig: String = requiredConfigForKey("hendelse.topic"),
-    val arenaVedtakTopic: String = requiredConfigForKey("arena.vedtak.topic"),
+    val arenaVedtakTopic: String? = runCatching { requiredConfigForKey("arena.vedtak.topic") }.getOrNull(),
     val internHendelseTopic: String = requiredConfigForKey("intern.hendelse.topic"),
 )


### PR DESCRIPTION
Fjerner `teamarenanais.aapen-arena-aapvedtakendret-v1-q2` fra dev da topic har feil nøkler. Gjør også  `arenaVedtakTopic` valgfri i config slik at consumer ikke startes når env-variabelen mangler