### PR TITLE
chore: add systemkatalog.nav.no/system label to nais manifest

### DIFF
--- a/.nais/application-dev.yml
+++ b/.nais/application-dev.yml
@@ -6,6 +6,7 @@ metadata:
   labels:
     team: aap
     sub: arena-hendelse-proxy
+    systemkatalog.nav.no/system: TE-496
 spec:
   image: {{image}}
   ingresses:

--- a/.nais/application-prod.yml
+++ b/.nais/application-prod.yml
@@ -6,6 +6,7 @@ metadata:
   labels:
     team: aap
     sub: arena-hendelse-proxy
+    systemkatalog.nav.no/system: TE-496
 spec:
   image: {{image}}
   ingresses:


### PR DESCRIPTION
Adds the `systemkatalog.nav.no/system: TE-496` label to the nais Application manifest so this app is registered in systemkatalog.nav.no.